### PR TITLE
Fix unseeded random generator

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -152,7 +152,11 @@ func GetUUID() string {
 const keyChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 func init() {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Seed the global random number generator so functions using
+	// math/rand generate non-deterministic results across runs.
+	// rand.New(...) creates a new generator which was discarded,
+	// leaving the global one unseeded. Use rand.Seed instead.
+	rand.Seed(time.Now().UnixNano())
 }
 
 func GenerateRandomCharsKey(length int) (string, error) {


### PR DESCRIPTION
## Summary
- ensure math/rand is seeded so random features work correctly

## Testing
- `go vet ./...` *(fails: proxyconnect tcp 172.21.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683a84d360788320bd02a223fc81f99b